### PR TITLE
Use the new setter for progress monitors in JGit

### DIFF
--- a/org.eclipse.egit.core/src/org/eclipse/egit/core/op/MergeOperation.java
+++ b/org.eclipse.egit.core/src/org/eclipse/egit/core/op/MergeOperation.java
@@ -32,6 +32,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.egit.core.Activator;
+import org.eclipse.egit.core.EclipseGitProgressTransformer;
 import org.eclipse.egit.core.internal.CoreText;
 import org.eclipse.egit.core.internal.job.RuleUtil;
 import org.eclipse.egit.core.internal.util.ProjectUtil;
@@ -180,7 +181,11 @@ public class MergeOperation implements IEGitOperation {
 				if (message != null)
 					merge.setMessage(message);
 				try {
-					mergeResult = merge.call();
+					// Every JGit command can receive a ProgressMonitor and
+					// return itself
+					mergeResult = merge.setProgressMonitor(
+							new EclipseGitProgressTransformer(mymonitor))
+							.call();
 					progress.worked(1);
 					if (MergeResult.MergeStatus.NOT_SUPPORTED.equals(mergeResult.getMergeStatus()))
 						throw new TeamException(new Status(IStatus.INFO, Activator.getPluginId(), mergeResult.toString()));


### PR DESCRIPTION
Only the class MergeOperation use this new setter for now. Other
operations should use it too in order to have a progress monitor
accessible for custom commands

Signed-off-by: mcartaud mathieu.cartaud@obeo.com
