### PR TITLE
Use default preferences to choose merge strategy

### DIFF
--- a/org.eclipse.egit.core/src/org/eclipse/egit/core/Activator.java
+++ b/org.eclipse.egit.core/src/org/eclipse/egit/core/Activator.java
@@ -248,18 +248,32 @@ public class Activator extends Plugin implements DebugOptionsListener {
 	 * @since 4.1
 	 */
 	public MergeStrategy getPreferredMergeStrategy() {
+		// Get preferences set by user in the UI
 		final IEclipsePreferences prefs = InstanceScope.INSTANCE
 				.getNode(Activator.getPluginId());
 		String preferredMergeStrategyKey = prefs.get(
 				GitCorePreferences.core_preferredMergeStrategy, null);
+
+		// Get preferences defined at eclipse startup with configuration files
+		if (preferredMergeStrategyKey == null
+				|| preferredMergeStrategyKey.isEmpty()) {
+			final IEclipsePreferences defaultPrefs = DefaultScope.INSTANCE
+					.getNode(Activator.getPluginId());
+			preferredMergeStrategyKey = defaultPrefs.get(
+					GitCorePreferences.core_preferredMergeStrategy, null);
+		}
 		if (preferredMergeStrategyKey != null
 				&& !preferredMergeStrategyKey.isEmpty()) {
 			MergeStrategy result = MergeStrategy.get(preferredMergeStrategyKey);
 			if (result != null) {
 				return result;
 			}
-			logError(NLS.bind(CoreText.Activator_invalidPreferredMergeStrategy,
-					preferredMergeStrategyKey), null);
+			if (!CoreText.MergeStrategy_JGit_Default
+					.equals(preferredMergeStrategyKey)) {
+				logError(NLS.bind(
+						CoreText.Activator_invalidPreferredMergeStrategy,
+						preferredMergeStrategyKey), null);
+			}
 		}
 		return null;
 	}

--- a/org.eclipse.egit.core/src/org/eclipse/egit/core/internal/CoreText.java
+++ b/org.eclipse.egit.core/src/org/eclipse/egit/core/internal/CoreText.java
@@ -245,6 +245,9 @@ public class CoreText extends NLS {
 	public static String MergeStrategy_UnloadError;
 
 	/** */
+	public static String MergeStrategy_JGit_Default;
+
+	/** */
 	public static String MoveDeleteHook_cannotModifyFolder;
 
 	/** */

--- a/org.eclipse.egit.core/src/org/eclipse/egit/core/internal/coretext.properties
+++ b/org.eclipse.egit.core/src/org/eclipse/egit/core/internal/coretext.properties
@@ -181,3 +181,4 @@ MergeStrategy_LoadError=An error occurred while trying to instantiate a register
 MergeStrategy_MissingName=A merge strategy must have a name. The unnamed strategy implemented by class {1} will be ignored
 MergeStrategy_DuplicateName=Another merge strategy is already registered by class {1} with the same name {0}. The strategy {0} implemented by class {2} will be ignored
 MergeStrategy_ReservedName=The strategy name {0} is reserved by JGit for class {1}. The strategy implemented by class {2} will be ignored
+MergeStrategy_JGit_Default=jgit-default-mergeStrategy

--- a/org.eclipse.egit.ui/src/org/eclipse/egit/ui/internal/preferences/SynchronizePreferencePage.java
+++ b/org.eclipse.egit.ui/src/org/eclipse/egit/ui/internal/preferences/SynchronizePreferencePage.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.egit.core.Activator.MergeStrategyDescriptor;
 import org.eclipse.egit.core.GitCorePreferences;
+import org.eclipse.egit.core.internal.CoreText;
 import org.eclipse.egit.ui.Activator;
 import org.eclipse.egit.ui.UIPreferences;
 import org.eclipse.egit.ui.internal.UIText;
@@ -99,8 +100,14 @@ public class SynchronizePreferencePage extends FieldEditorPreferencePage
 		org.eclipse.egit.core.Activator coreActivator = org.eclipse.egit.core.Activator
 				.getDefault();
 		List<String[]> strategies = new ArrayList<>();
+
+		// We need to add a default name for EGit default strategy in order to
+		// be able to distinguish a state where user have not choose any
+		// preferences (in this case, values defined in eclipse configuration
+		// files may apply) or if he has chosen the default merge strategy.
 		strategies.add(new String[] {
-				UIText.GitPreferenceRoot_defaultMergeStrategyLabel, "" }); //$NON-NLS-1$
+				UIText.GitPreferenceRoot_defaultMergeStrategyLabel,
+				CoreText.MergeStrategy_JGit_Default });
 		for (MergeStrategyDescriptor strategy : coreActivator
 				.getRegisteredMergeStrategies()) {
 			strategies.add(new String[] { strategy.getLabel(),


### PR DESCRIPTION
The default preferences are only used if the user has not set a
preference through the preferences pages

Signed-off-by: mcartaud mathieu.cartaud@obeo.com
